### PR TITLE
input imgs to RGB

### DIFF
--- a/streamlit.py
+++ b/streamlit.py
@@ -113,7 +113,7 @@ def main():
   if image_file is not None:
     if st.button("Predicting the type of residue"):
       st.image (image_file, caption = 'Uploaded Image.', use_column_width = True)
-      image = Image.open(image_file)
+      image = Image.open(image_file).convert('RGB')
       transformations = load_transformations()
       example_image = transformations(image)
       model = load_Model()


### PR DESCRIPTION
# Converting all input images to common RGB format

As the title describes, this way we ensure all input images are converted to a common RGB format readable by the learning model (issue #1 ).

I simply added the convert('RGB') method to the input image opening method.